### PR TITLE
Filter out only the container endpoints of `veth` interfaces

### DIFF
--- a/veth.sh
+++ b/veth.sh
@@ -3,7 +3,7 @@
 NAME=$1
 PID=$(docker inspect $NAME --format "{{.State.Pid}}")
 while read iface id; do
-        [[ "$iface" == lo ]] && continue
+        [[ "$iface" == lo || ! "$iface" = eth* ]] && continue
         veth=$(ip -br addr | sed -nre "s/(veth.*)@if$id.*/\1/p")
         echo -e "$NAME\t$iface\t$veth"
 done < <(</proc/$PID/net/igmp awk '/^[0-9]+/{print $2 " " $1;}')

--- a/veth.sh
+++ b/veth.sh
@@ -6,4 +6,4 @@ while read iface id; do
         [[ "$iface" == lo || ! "$iface" = eth* ]] && continue
         veth=$(ip -br addr | sed -nre "s/(veth.*)@if$id.*/\1/p")
         echo -e "$NAME\t$iface\t$veth"
-done < <(</proc/$PID/net/igmp awk '/^[0-9]+/{print $2 " " $1;}')
+done < <(awk </proc/$PID/net/igmp '/^[0-9]+/{print $2 " " $1;}')


### PR DESCRIPTION
Avoid printing invalid entries for non-`veth` interfaces.